### PR TITLE
Fix non-recursive translation

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -46,7 +46,8 @@ ifneq ($(SESSION),"Pure")
 build: $(ISADB_DIR)/$(SESSION).db
 
 $(ISADB_DIR)/%.db: $(ROOT_DIR)/ROOT $(SESSION_DIR)
-	isabelle build -c -b -d$(ROOT_DIR) $*
+	isabelle build -b -d$(ROOT_DIR) $*
+	@touch $@
 
 $(SESSION_DIR):
 	mkdir -p $@

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -46,7 +46,7 @@ ifneq ($(SESSION),"Pure")
 build: $(ISADB_DIR)/$(SESSION).db
 
 $(ISADB_DIR)/%.db: $(ROOT_DIR)/ROOT $(SESSION_DIR)
-	isabelle build -b -d$(ROOT_DIR) $*
+	isabelle build -c -b -d$(ROOT_DIR) $*
 
 $(SESSION_DIR):
 	mkdir -p $@

--- a/src/exporter.scala
+++ b/src/exporter.scala
@@ -281,10 +281,6 @@ object Exporter {
           if (verbose) progress.echo("  "+a.toString+" "+a.serial)
           Translate.type_decl(theory_name, a.name, a.the_content.args, None, No_Syntax)
         }
-        for (a <- theory.classes) {
-          if (verbose) progress.echo("  "+a.toString+" "+a.serial)
-          Translate.class_decl(theory_name, a.name, None)
-        }
         for (a <- theory.consts) {
           if (verbose) progress.echo("  "+a.toString+" "+a.serial)
           Translate.const_decl(theory_name, a.name, a.the_content.typargs, a.the_content.typ, None, No_Syntax)

--- a/src/exporter.scala
+++ b/src/exporter.scala
@@ -116,6 +116,15 @@ object Exporter {
     }
   }
 
+  /** whether an $isa term is a free variable, possibly lambda-abstracted */
+  @tailrec
+  def is_abstract_free(term: Term): Boolean = term match {
+    case Abs(_, _, remainder) => is_abstract_free(remainder)
+    case App(remainder, Bound(_)) => is_abstract_free(remainder)
+    case Free(_, _) => true
+    case _ => false
+  }
+
   /** Reads an $isa session and possibly translates it to $dk files
    * 
    * @param options $isa options to read the session
@@ -270,10 +279,24 @@ object Exporter {
     if (!translate) { /* if translate is false, just update maps to keep in mind
                          the translated names of the session, but do not
                          write anything anywhere
-                      */ 
+                      */
       progress.echo("Start reading session "+session)
       for (thy <- thys) {
         val theory_name = thy.toString
+        
+        /** Same as remove_useless_proofs (below) but only update the Translate.replace_serial map */
+        @tailrec
+        def update_useless_proofs(name: String, proof: Term.Proof): Unit = proof match {
+          case PThm(serial, origin_theory, _, _) if origin_theory == theory_name &
+            !Translate.replace_serial.contains(serial) =>
+            Translate.replace_serial += serial -> name
+            // otherwise scala does not recognise tail recursiveness
+            val next_proof = use_proof(theory_name, serial) { case (prf, _) => prf }
+            update_useless_proofs(name, next_proof)
+          case Appt(rem, arg) if is_abstract_free(arg) => update_useless_proofs(name, rem)
+          case _ =>
+        }
+        
         progress.echo("Start reading theory "+theory_name)
         val provider = ses_cont.theory(theory_name, other_cache=Some(term_cache))
         val theory = read_theory(provider)
@@ -292,6 +315,7 @@ object Exporter {
         for (a <- theory.thms) {
           if (verbose) progress.echo("  " + a.toString + " " + a.serial)
           Translate.stmt_decl(Prelude.add_thm_ident(a.name, theory_name), a.the_content.prop, None)
+          update_useless_proofs(a.name, a.the_content.proof)
         }
         progress.echo("End reading theory "+theory_name)
       }
@@ -498,15 +522,6 @@ object Exporter {
              * and <code>None</code> if it is to be erased. */
             var replace_serial: Map[Long, Option[String]] = Map()
 
-            /** whether an Isabelle term is a free variable, possibly lambda-abstracted */
-            @tailrec
-            def is_abstract_free(term: Term):Boolean = term match {
-              case Abs(_,_,remainder) => is_abstract_free(remainder)
-              case App(remainder,Bound(_)) => is_abstract_free(remainder)
-              case Free(_,_) => true
-              case _ => false
-            }
-
             /** In $isa, Some theorem proofs are a reference to an unnamed lemma proving the exact same
              * statement. This function recursively inspects the proof of a theorem to delete all such useless lemmas
              * by updating the replace_serial map
@@ -518,8 +533,8 @@ object Exporter {
              *                           in the numbering order) will have its declaration replaced by the
              *                           theorem's one
              * @return true if no such lemma was found, indicating that the theorem should be stated on its own
-             * @define isa <span style="color:#FFFF00">Isabelle</span>
-             * @define arg code><span style="color:#FFC0CB;"
+             * @define isa  <span style="color:#FFFF00">Isabelle</span>
+             * @define arg  code><span style="color:#FFC0CB;"
              * @define arge /span></code
              */
             @tailrec
@@ -527,20 +542,20 @@ object Exporter {
                                       encountered_lemmas: List[Long] = Nil): Boolean = proof match {
               case PThm(serial, origin_theory, _, _) if origin_theory == theory_name &
                 !Translate.replace_serial.contains(serial) =>
-                  Translate.replace_serial += serial -> name
-                  // otherwise scala does not recognise tail recursiveness
-                  val next_proof = use_proof(theory_name,serial){case (prf,_) => prf}
-                  remove_useless_proofs(name,next_proof,serial::encountered_lemmas)
-              case Appt(rem, arg) if is_abstract_free(arg) => remove_useless_proofs(name,rem,encountered_lemmas)
+                Translate.replace_serial += serial -> name
+                // otherwise scala does not recognise tail recursiveness
+                val next_proof = use_proof(theory_name, serial) { case (prf, _) => prf }
+                remove_useless_proofs(name, next_proof, serial :: encountered_lemmas)
+              case Appt(rem, arg) if is_abstract_free(arg) => remove_useless_proofs(name, rem, encountered_lemmas)
               case _ =>
                 encountered_lemmas match {
-                case final_lemma::remainder =>
-                  replace_serial += final_lemma -> Some(name)
-                  for (lemma <- remainder) replace_serial += lemma -> None
-                  false
-                case _ => true
+                  case final_lemma :: remainder =>
+                    replace_serial += final_lemma -> Some(name)
+                    for (lemma <- remainder) replace_serial += lemma -> None
+                    false
+                  case _ => true
                 }
-              }
+            }
 
             /** function writing the declaration of a lemma for an intermediary proof */
             def write_proof(prf: Long): Unit = {

--- a/src/exporter.scala
+++ b/src/exporter.scala
@@ -283,12 +283,12 @@ object Exporter {
       progress.echo("Start reading session "+session)
       for (thy <- thys) {
         val theory_name = thy.toString
-        
+
         /** Same as remove_useless_proofs (below) but only update the Translate.replace_serial map */
         @tailrec
         def update_useless_proofs(name: String, proof: Term.Proof): Unit = proof match {
-          case PThm(serial, origin_theory, _, _) if origin_theory == theory_name &
-            !Translate.replace_serial.contains(serial) =>
+          case PThm(serial, origin_theory, thm_name, _) if thm_name.is_empty &&
+            origin_theory == theory_name & !Translate.replace_serial.contains(serial) =>
             Translate.replace_serial += serial -> name
             // otherwise scala does not recognise tail recursiveness
             val next_proof = use_proof(theory_name, serial) { case (prf, _) => prf }
@@ -296,7 +296,7 @@ object Exporter {
           case Appt(rem, arg) if is_abstract_free(arg) => update_useless_proofs(name, rem)
           case _ =>
         }
-        
+
         progress.echo("Start reading theory "+theory_name)
         val provider = ses_cont.theory(theory_name, other_cache=Some(term_cache))
         val theory = read_theory(provider)
@@ -540,8 +540,8 @@ object Exporter {
             @tailrec
             def remove_useless_proofs(name: String, proof: Term.Proof,
                                       encountered_lemmas: List[Long] = Nil): Boolean = proof match {
-              case PThm(serial, origin_theory, _, _) if origin_theory == theory_name &
-                !Translate.replace_serial.contains(serial) =>
+              case PThm(serial, origin_theory, thm_name, _) if thm_name.is_empty &&
+                origin_theory == theory_name && !Translate.replace_serial.contains(serial) =>
                 Translate.replace_serial += serial -> name
                 // otherwise scala does not recognise tail recursiveness
                 val next_proof = use_proof(theory_name, serial) { case (prf, _) => prf }


### PR DESCRIPTION
- Do not read classes twice when reading a session
- Update useless proofs map when reading a session
- Do not remove named theorems  
