### PR TITLE
ROOT: add _wp suffix to session names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,15 +56,15 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-version }}
       - name: Install dkcheck
         run: opam install dedukti.${{ matrix.dedukti-version }}
-      - name: Check dk output for HOL_Groups
+      - name: Check dk output for HOL_Groups_wp
         run: |
           eval $(opam env)
           export PATH=$PATH:~/Isabelle${{ matrix.isabelle-version }}/bin
           cd examples
           make SESSION=Pure dk
           make SESSION=Pure dko
-          make SESSION=HOL_Groups dk
-          make SESSION=HOL_Groups dko
+          make SESSION=HOL_Groups_wp dk
+          make SESSION=HOL_Groups_wp dko
 #          mkdir -p kocheck
 #          ../../remove-requires.sh *.dk
 #          cd kocheck
@@ -79,12 +79,12 @@ jobs:
 #          git clone https://github.com/01mf02/kontroli-rs.git
 #          cd ~/kontroli-rs
 #          cargo install --path kocheck
-      - name: Generate and check lp output for HOL_Groups
+      - name: Generate and check lp output for HOL_Groups_wp
         run: |
           eval $(opam env)
           export PATH=$PATH:~/Isabelle${{ matrix.isabelle-version }}/bin
           cd examples
           make SESSION=Pure lp
           make SESSION=Pure lpo
-          make SESSION=HOL_Groups lp
-          make SESSION=HOL_Groups lpo
+          make SESSION=HOL_Groups_wp lp
+          make SESSION=HOL_Groups_wp lpo

--- a/HOL.patch
+++ b/HOL.patch
@@ -1,6 +1,6 @@
-diff -urNx '*~' -x '*.orig' Enum.thy Enum.thy
---- Enum.thy	2025-03-12 19:39:00.000000000 +0900
-+++ Enum.thy	2025-12-11 13:22:51.037338559 +0900
+diff -urNx *~ -x *.orig ./Enum.thy ../../src/HOL/Enum.thy
+--- ./Enum.thy	2024-12-18 15:58:48
++++ ../../src/HOL/Enum.thy	2024-12-18 15:55:54
 @@ -929,15 +929,47 @@
  definition "x mod y = (case y of a\<^sub>1 \<Rightarrow> x | _ \<Rightarrow> a\<^sub>1)"
  definition "abs = (\<lambda>x. case x of a\<^sub>3 \<Rightarrow> a\<^sub>2 | _ \<Rightarrow> x)"
@@ -189,23 +189,9 @@ diff -urNx '*~' -x '*.orig' Enum.thy Enum.thy
  end
  
  
-diff -urNx '*~' -x '*.orig' List.thy List.thy
---- List.thy	2025-03-12 19:39:00.000000000 +0900
-+++ List.thy	2025-12-11 13:23:56.747319353 +0900
-@@ -3790,7 +3790,9 @@
- 
- lemma distinct_swap[simp]: "\<lbrakk> i < size xs; j < size xs\<rbrakk> \<Longrightarrow>
-   distinct(xs[i := xs!j, j := xs!i]) = distinct xs"
--  by (smt (verit, del_insts) distinct_conv_nth length_list_update nth_list_update)
-+  apply (simp add: distinct_conv_nth nth_list_update)
-+  apply (safe; metis)
-+  done
- 
- lemma set_swap[simp]:
-   "\<lbrakk> i < size xs; j < size xs \<rbrakk> \<Longrightarrow> set(xs[i := xs!j, j := xs!i]) = set xs"
-diff -urNx '*~' -x '*.orig' MacLaurin.thy MacLaurin.thy
---- MacLaurin.thy	2025-03-12 19:39:00.000000000 +0900
-+++ MacLaurin.thy	2025-12-11 13:22:51.037338559 +0900
+diff -urNx *~ -x *.orig ./MacLaurin.thy ../../src/HOL/MacLaurin.thy
+--- ./MacLaurin.thy	2024-12-18 15:58:48
++++ ../../src/HOL/MacLaurin.thy	2024-12-18 15:55:54
 @@ -22,7 +22,7 @@
  
  lemma eq_diff_eq': "x = y - z \<longleftrightarrow> y = x + z"
@@ -246,7 +232,7 @@ diff -urNx '*~' -x '*.orig' MacLaurin.thy MacLaurin.thy
  qed auto
  
  lemma Maclaurin_sin_expansion:
-@@ -346,8 +348,7 @@
+@@ -348,8 +350,7 @@
    then show ?thesis
      apply (rule ex_forward, simp)
      apply (rule sum.cong[OF refl])
@@ -256,7 +242,7 @@ diff -urNx '*~' -x '*.orig' MacLaurin.thy MacLaurin.thy
  qed
  
  lemma Maclaurin_sin_expansion4:
-@@ -365,8 +366,7 @@
+@@ -369,8 +370,7 @@
    then show ?thesis
      apply (rule ex_forward, simp)
      apply (rule sum.cong[OF refl])
@@ -266,7 +252,7 @@ diff -urNx '*~' -x '*.orig' MacLaurin.thy MacLaurin.thy
  qed
  
  
-@@ -378,6 +378,16 @@
+@@ -382,6 +382,16 @@
  lemma cos_expansion_lemma: "cos (x + real (Suc m) * pi / 2) = - sin (x + real m * pi / 2)"
    by (auto simp: cos_add sin_add distrib_right add_divide_distrib)
  
@@ -283,7 +269,7 @@ diff -urNx '*~' -x '*.orig' MacLaurin.thy MacLaurin.thy
  lemma Maclaurin_cos_expansion:
    "\<exists>t::real. \<bar>t\<bar> \<le> \<bar>x\<bar> \<and>
      cos x = (\<Sum>m<n. cos_coeff m * x ^ m) + (cos(t + 1/2 * real n * pi) / fact n) * x ^ n"
-@@ -395,8 +405,7 @@
+@@ -399,8 +409,7 @@
    then show ?thesis
      apply (rule ex_forward, simp)
      apply (rule sum.cong[OF refl])
@@ -293,7 +279,7 @@ diff -urNx '*~' -x '*.orig' MacLaurin.thy MacLaurin.thy
  qed auto
  
  lemma Maclaurin_cos_expansion2:
-@@ -415,8 +424,7 @@
+@@ -419,8 +428,7 @@
    then show ?thesis
      apply (rule ex_forward, simp)
      apply (rule sum.cong[OF refl])
@@ -303,7 +289,7 @@ diff -urNx '*~' -x '*.orig' MacLaurin.thy MacLaurin.thy
  qed
  
  lemma Maclaurin_minus_cos_expansion:
-@@ -435,8 +443,7 @@
+@@ -439,8 +447,7 @@
    then show ?thesis
      apply (rule ex_forward, simp)
      apply (rule sum.cong[OF refl])
@@ -313,10 +299,10 @@ diff -urNx '*~' -x '*.orig' MacLaurin.thy MacLaurin.thy
  qed
  
  
-diff -urNx '*~' -x '*.orig' Quickcheck_Narrowing.thy Quickcheck_Narrowing.thy
---- Quickcheck_Narrowing.thy	2025-03-12 19:39:00.000000000 +0900
-+++ Quickcheck_Narrowing.thy	2025-12-11 13:22:51.038338543 +0900
-@@ -197,8 +197,10 @@
+diff -urNx *~ -x *.orig ./Quickcheck_Narrowing.thy ../../src/HOL/Quickcheck_Narrowing.thy
+--- ./Quickcheck_Narrowing.thy	2024-12-18 15:58:48
++++ ../../src/HOL/Quickcheck_Narrowing.thy	2024-12-18 15:55:55
+@@ -196,8 +196,10 @@
  
  external_file \<open>~~/src/HOL/Tools/Quickcheck/Narrowing_Engine.hs\<close>
  external_file \<open>~~/src/HOL/Tools/Quickcheck/PNF_Narrowing_Engine.hs\<close>
@@ -327,7 +313,7 @@ diff -urNx '*~' -x '*.orig' Quickcheck_Narrowing.thy Quickcheck_Narrowing.thy
  definition narrowing_dummy_partial_term_of :: "('a :: partial_term_of) itself => narrowing_term => term"
  where
    "narrowing_dummy_partial_term_of = partial_term_of"
-@@ -207,6 +209,7 @@
+@@ -206,6 +208,7 @@
  where
    "narrowing_dummy_narrowing = narrowing"
  
@@ -335,7 +321,7 @@ diff -urNx '*~' -x '*.orig' Quickcheck_Narrowing.thy Quickcheck_Narrowing.thy
  lemma [code]:
    "ensure_testable f =
      (let
-@@ -214,9 +217,11 @@
+@@ -213,9 +216,11 @@
        y = narrowing_dummy_partial_term_of :: bool itself => narrowing_term => term;
        z = (conv :: _ => _ => unit)  in f)"
  unfolding Let_def ensure_testable_def ..
@@ -347,7 +333,7 @@ diff -urNx '*~' -x '*.orig' Quickcheck_Narrowing.thy Quickcheck_Narrowing.thy
  instantiation set :: (narrowing) narrowing
  begin
  
-@@ -226,6 +231,7 @@
+@@ -225,6 +230,7 @@
  
  end
    
@@ -355,7 +341,7 @@ diff -urNx '*~' -x '*.orig' Quickcheck_Narrowing.thy Quickcheck_Narrowing.thy
  subsection \<open>Narrowing for integers\<close>
  
  
-@@ -265,6 +271,7 @@
+@@ -264,6 +270,7 @@
  
  end
  
@@ -363,7 +349,7 @@ diff -urNx '*~' -x '*.orig' Quickcheck_Narrowing.thy Quickcheck_Narrowing.thy
  declare [[code drop: "partial_term_of :: int itself \<Rightarrow> _"]]
  
  lemma [code]:
-@@ -275,6 +282,7 @@
+@@ -274,6 +281,7 @@
       then Code_Evaluation.term_of (- (int_of_integer i) div 2)
       else Code_Evaluation.term_of ((int_of_integer i + 1) div 2))"
    by (rule partial_term_of_anything)+
@@ -371,7 +357,7 @@ diff -urNx '*~' -x '*.orig' Quickcheck_Narrowing.thy Quickcheck_Narrowing.thy
  
  instantiation integer :: narrowing
  begin
-@@ -287,6 +295,7 @@
+@@ -286,6 +294,7 @@
  
  end
  
@@ -379,7 +365,7 @@ diff -urNx '*~' -x '*.orig' Quickcheck_Narrowing.thy Quickcheck_Narrowing.thy
  declare [[code drop: "partial_term_of :: integer itself \<Rightarrow> _"]]  
  
  lemma [code]:
-@@ -297,6 +306,7 @@
+@@ -296,6 +305,7 @@
       then Code_Evaluation.term_of (- i div 2)
       else Code_Evaluation.term_of ((i + 1) div 2))"
    by (rule partial_term_of_anything)+
@@ -387,10 +373,10 @@ diff -urNx '*~' -x '*.orig' Quickcheck_Narrowing.thy Quickcheck_Narrowing.thy
  
  code_printing constant "Code_Evaluation.term_of :: integer \<Rightarrow> term" \<rightharpoonup> (Haskell_Quickcheck) 
    "(let { t = Typerep.Typerep \"Code'_Numeral.integer\" [];
-diff -urNx '*~' -x '*.orig' Quickcheck_Random.thy Quickcheck_Random.thy
---- Quickcheck_Random.thy	2025-03-12 19:39:00.000000000 +0900
-+++ Quickcheck_Random.thy	2025-12-11 13:22:51.038338543 +0900
-@@ -230,7 +230,7 @@
+diff -urNx *~ -x *.orig ./Quickcheck_Random.thy ../../src/HOL/Quickcheck_Random.thy
+--- ./Quickcheck_Random.thy	2024-12-18 15:58:48
++++ ../../src/HOL/Quickcheck_Random.thy	2024-12-18 15:55:54
+@@ -229,7 +229,7 @@
         (Code_Numeral.Suc i,
          random j \<circ>\<rightarrow> (%x. random_aux_set i j \<circ>\<rightarrow> (%s. Pair (valtermify_insert x s))))])"
  
@@ -399,9 +385,9 @@ diff -urNx '*~' -x '*.orig' Quickcheck_Random.thy Quickcheck_Random.thy
    "random_aux_set i j =
      collapse (Random.select_weight [(1, Pair valterm_emptyset),
        (i, random j \<circ>\<rightarrow> (%x. random_aux_set (i - 1) j \<circ>\<rightarrow> (%s. Pair (valtermify_insert x s))))])"
-diff -urNx '*~' -x '*.orig' String.thy String.thy
---- String.thy	2025-03-12 19:39:00.000000000 +0900
-+++ String.thy	2025-12-11 13:22:51.038338543 +0900
+diff -urNx *~ -x *.orig ./String.thy ../../src/HOL/String.thy
+--- ./String.thy	2024-12-18 15:58:48
++++ ../../src/HOL/String.thy	2024-12-18 15:55:55
 @@ -40,11 +40,21 @@
  
  lemma (in comm_semiring_1) of_nat_of_char:
@@ -426,7 +412,7 @@ diff -urNx '*~' -x '*.orig' String.thy String.thy
  
  lemma nat_of_char [simp]:
    \<open>nat (of_char c) = of_char c\<close>
-@@ -714,9 +724,9 @@
+@@ -698,9 +708,9 @@
  
  lemma [code]:
    \<open>Literal' b0 b1 b2 b3 b4 b5 b6 s = String.literal_of_asciis
@@ -438,10 +424,10 @@ diff -urNx '*~' -x '*.orig' String.thy String.thy
      by simp
    moreover have \<open>Literal' b0 b1 b2 b3 b4 b5 b6 s = String.literal_of_asciis
      [of_char (Char b0 b1 b2 b3 b4 b5 b6 False)] + s\<close>
-diff -urNx '*~' -x '*.orig' Tools/Quickcheck/exhaustive_generators.ML Tools/Quickcheck/exhaustive_generators.ML
---- Tools/Quickcheck/exhaustive_generators.ML	2025-03-12 19:39:00.000000000 +0900
-+++ Tools/Quickcheck/exhaustive_generators.ML	2025-12-11 13:22:51.039338527 +0900
-@@ -544,7 +544,7 @@
+diff -urNx *~ -x *.orig ./Tools/Quickcheck/exhaustive_generators.ML ../../src/HOL/Tools/Quickcheck/exhaustive_generators.ML
+--- ./Tools/Quickcheck/exhaustive_generators.ML	2024-12-18 15:58:48
++++ ../../src/HOL/Tools/Quickcheck/exhaustive_generators.ML	2024-12-18 15:55:54
+@@ -546,7 +546,7 @@
          instantiate_bounded_forall_datatype)))
  
  val active = Attrib.setup_config_bool \<^binding>\<open>quickcheck_exhaustive_active\<close> (K true)
@@ -450,16 +436,16 @@ diff -urNx '*~' -x '*.orig' Tools/Quickcheck/exhaustive_generators.ML Tools/Quic
  val _ =
    Theory.setup
     (Quickcheck_Common.datatype_interpretation \<^plugin>\<open>quickcheck_full_exhaustive\<close>
-@@ -552,5 +552,5 @@
+@@ -554,5 +554,5 @@
      #> Context.theory_map (Quickcheck.add_tester ("exhaustive", (active, test_goals)))
      #> Context.theory_map (Quickcheck.add_batch_generator ("exhaustive", compile_generator_exprs))
      #> Context.theory_map (Quickcheck.add_batch_validator ("exhaustive", compile_validator_exprs)))
 -
 +*)
  end
-diff -urNx '*~' -x '*.orig' Tools/Quickcheck/narrowing_generators.ML Tools/Quickcheck/narrowing_generators.ML
---- Tools/Quickcheck/narrowing_generators.ML	2025-03-12 19:39:00.000000000 +0900
-+++ Tools/Quickcheck/narrowing_generators.ML	2025-12-11 13:22:51.039338527 +0900
+diff -urNx *~ -x *.orig ./Tools/Quickcheck/narrowing_generators.ML ../../src/HOL/Tools/Quickcheck/narrowing_generators.ML
+--- ./Tools/Quickcheck/narrowing_generators.ML	2024-12-18 15:58:48
++++ ../../src/HOL/Tools/Quickcheck/narrowing_generators.ML	2024-12-18 15:55:54
 @@ -542,8 +542,10 @@
    Theory.setup
     (Code.datatype_interpretation ensure_partial_term_of
@@ -471,9 +457,9 @@ diff -urNx '*~' -x '*.orig' Tools/Quickcheck/narrowing_generators.ML Tools/Quick
      #> Context.theory_map (Quickcheck.add_tester ("narrowing", (active, test_goals))))
  
  end
-diff -urNx '*~' -x '*.orig' Tools/Quickcheck/random_generators.ML Tools/Quickcheck/random_generators.ML
---- Tools/Quickcheck/random_generators.ML	2025-03-12 19:39:00.000000000 +0900
-+++ Tools/Quickcheck/random_generators.ML	2025-12-11 13:22:51.039338527 +0900
+diff -urNx *~ -x *.orig ./Tools/Quickcheck/random_generators.ML ../../src/HOL/Tools/Quickcheck/random_generators.ML
+--- ./Tools/Quickcheck/random_generators.ML	2024-12-18 15:58:48
++++ ../../src/HOL/Tools/Quickcheck/random_generators.ML	2024-12-18 15:55:54
 @@ -481,10 +481,12 @@
  
  val active = Attrib.setup_config_bool \<^binding>\<open>quickcheck_random_active\<close> (K false);
@@ -487,10 +473,10 @@ diff -urNx '*~' -x '*.orig' Tools/Quickcheck/random_generators.ML Tools/Quickche
 +*)
  
  end;
-diff -urNx '*~' -x '*.orig' Transcendental.thy Transcendental.thy
---- Transcendental.thy	2025-03-12 19:39:00.000000000 +0900
-+++ Transcendental.thy	2025-12-11 13:22:51.041338495 +0900
-@@ -3526,8 +3526,9 @@
+diff -urNx *~ -x *.orig ./Transcendental.thy ../../src/HOL/Transcendental.thy
+--- ./Transcendental.thy	2024-12-18 15:58:48
++++ ../../src/HOL/Transcendental.thy	2024-12-18 15:55:54
+@@ -3572,8 +3572,9 @@
          using \<open>n \<le> p\<close> neq0_conv that(1) by blast
        then have \<section>: "(- 1::real) ^ (p div 2 - Suc 0) = - ((- 1) ^ (p div 2))"
          using \<open>even p\<close> by (auto simp add: dvd_def power_eq_if)

--- a/HOL.patch
+++ b/HOL.patch
@@ -1,6 +1,6 @@
-diff -urNx *~ -x *.orig ./Enum.thy ../../src/HOL/Enum.thy
---- ./Enum.thy	2024-12-18 15:58:48
-+++ ../../src/HOL/Enum.thy	2024-12-18 15:55:54
+diff -urNx '*~' -x '*.orig' Enum.thy Enum.thy
+--- Enum.thy	2025-03-12 19:39:00.000000000 +0900
++++ Enum.thy	2025-12-11 13:22:51.037338559 +0900
 @@ -929,15 +929,47 @@
  definition "x mod y = (case y of a\<^sub>1 \<Rightarrow> x | _ \<Rightarrow> a\<^sub>1)"
  definition "abs = (\<lambda>x. case x of a\<^sub>3 \<Rightarrow> a\<^sub>2 | _ \<Rightarrow> x)"
@@ -189,9 +189,23 @@ diff -urNx *~ -x *.orig ./Enum.thy ../../src/HOL/Enum.thy
  end
  
  
-diff -urNx *~ -x *.orig ./MacLaurin.thy ../../src/HOL/MacLaurin.thy
---- ./MacLaurin.thy	2024-12-18 15:58:48
-+++ ../../src/HOL/MacLaurin.thy	2024-12-18 15:55:54
+diff -urNx '*~' -x '*.orig' List.thy List.thy
+--- List.thy	2025-03-12 19:39:00.000000000 +0900
++++ List.thy	2025-12-11 13:23:56.747319353 +0900
+@@ -3790,7 +3790,9 @@
+ 
+ lemma distinct_swap[simp]: "\<lbrakk> i < size xs; j < size xs\<rbrakk> \<Longrightarrow>
+   distinct(xs[i := xs!j, j := xs!i]) = distinct xs"
+-  by (smt (verit, del_insts) distinct_conv_nth length_list_update nth_list_update)
++  apply (simp add: distinct_conv_nth nth_list_update)
++  apply (safe; metis)
++  done
+ 
+ lemma set_swap[simp]:
+   "\<lbrakk> i < size xs; j < size xs \<rbrakk> \<Longrightarrow> set(xs[i := xs!j, j := xs!i]) = set xs"
+diff -urNx '*~' -x '*.orig' MacLaurin.thy MacLaurin.thy
+--- MacLaurin.thy	2025-03-12 19:39:00.000000000 +0900
++++ MacLaurin.thy	2025-12-11 13:22:51.037338559 +0900
 @@ -22,7 +22,7 @@
  
  lemma eq_diff_eq': "x = y - z \<longleftrightarrow> y = x + z"
@@ -232,7 +246,7 @@ diff -urNx *~ -x *.orig ./MacLaurin.thy ../../src/HOL/MacLaurin.thy
  qed auto
  
  lemma Maclaurin_sin_expansion:
-@@ -348,8 +350,7 @@
+@@ -346,8 +348,7 @@
    then show ?thesis
      apply (rule ex_forward, simp)
      apply (rule sum.cong[OF refl])
@@ -242,7 +256,7 @@ diff -urNx *~ -x *.orig ./MacLaurin.thy ../../src/HOL/MacLaurin.thy
  qed
  
  lemma Maclaurin_sin_expansion4:
-@@ -369,8 +370,7 @@
+@@ -365,8 +366,7 @@
    then show ?thesis
      apply (rule ex_forward, simp)
      apply (rule sum.cong[OF refl])
@@ -252,7 +266,7 @@ diff -urNx *~ -x *.orig ./MacLaurin.thy ../../src/HOL/MacLaurin.thy
  qed
  
  
-@@ -382,6 +382,16 @@
+@@ -378,6 +378,16 @@
  lemma cos_expansion_lemma: "cos (x + real (Suc m) * pi / 2) = - sin (x + real m * pi / 2)"
    by (auto simp: cos_add sin_add distrib_right add_divide_distrib)
  
@@ -269,7 +283,7 @@ diff -urNx *~ -x *.orig ./MacLaurin.thy ../../src/HOL/MacLaurin.thy
  lemma Maclaurin_cos_expansion:
    "\<exists>t::real. \<bar>t\<bar> \<le> \<bar>x\<bar> \<and>
      cos x = (\<Sum>m<n. cos_coeff m * x ^ m) + (cos(t + 1/2 * real n * pi) / fact n) * x ^ n"
-@@ -399,8 +409,7 @@
+@@ -395,8 +405,7 @@
    then show ?thesis
      apply (rule ex_forward, simp)
      apply (rule sum.cong[OF refl])
@@ -279,7 +293,7 @@ diff -urNx *~ -x *.orig ./MacLaurin.thy ../../src/HOL/MacLaurin.thy
  qed auto
  
  lemma Maclaurin_cos_expansion2:
-@@ -419,8 +428,7 @@
+@@ -415,8 +424,7 @@
    then show ?thesis
      apply (rule ex_forward, simp)
      apply (rule sum.cong[OF refl])
@@ -289,7 +303,7 @@ diff -urNx *~ -x *.orig ./MacLaurin.thy ../../src/HOL/MacLaurin.thy
  qed
  
  lemma Maclaurin_minus_cos_expansion:
-@@ -439,8 +447,7 @@
+@@ -435,8 +443,7 @@
    then show ?thesis
      apply (rule ex_forward, simp)
      apply (rule sum.cong[OF refl])
@@ -299,10 +313,10 @@ diff -urNx *~ -x *.orig ./MacLaurin.thy ../../src/HOL/MacLaurin.thy
  qed
  
  
-diff -urNx *~ -x *.orig ./Quickcheck_Narrowing.thy ../../src/HOL/Quickcheck_Narrowing.thy
---- ./Quickcheck_Narrowing.thy	2024-12-18 15:58:48
-+++ ../../src/HOL/Quickcheck_Narrowing.thy	2024-12-18 15:55:55
-@@ -196,8 +196,10 @@
+diff -urNx '*~' -x '*.orig' Quickcheck_Narrowing.thy Quickcheck_Narrowing.thy
+--- Quickcheck_Narrowing.thy	2025-03-12 19:39:00.000000000 +0900
++++ Quickcheck_Narrowing.thy	2025-12-11 13:22:51.038338543 +0900
+@@ -197,8 +197,10 @@
  
  external_file \<open>~~/src/HOL/Tools/Quickcheck/Narrowing_Engine.hs\<close>
  external_file \<open>~~/src/HOL/Tools/Quickcheck/PNF_Narrowing_Engine.hs\<close>
@@ -313,7 +327,7 @@ diff -urNx *~ -x *.orig ./Quickcheck_Narrowing.thy ../../src/HOL/Quickcheck_Narr
  definition narrowing_dummy_partial_term_of :: "('a :: partial_term_of) itself => narrowing_term => term"
  where
    "narrowing_dummy_partial_term_of = partial_term_of"
-@@ -206,6 +208,7 @@
+@@ -207,6 +209,7 @@
  where
    "narrowing_dummy_narrowing = narrowing"
  
@@ -321,7 +335,7 @@ diff -urNx *~ -x *.orig ./Quickcheck_Narrowing.thy ../../src/HOL/Quickcheck_Narr
  lemma [code]:
    "ensure_testable f =
      (let
-@@ -213,9 +216,11 @@
+@@ -214,9 +217,11 @@
        y = narrowing_dummy_partial_term_of :: bool itself => narrowing_term => term;
        z = (conv :: _ => _ => unit)  in f)"
  unfolding Let_def ensure_testable_def ..
@@ -333,7 +347,7 @@ diff -urNx *~ -x *.orig ./Quickcheck_Narrowing.thy ../../src/HOL/Quickcheck_Narr
  instantiation set :: (narrowing) narrowing
  begin
  
-@@ -225,6 +230,7 @@
+@@ -226,6 +231,7 @@
  
  end
    
@@ -341,7 +355,7 @@ diff -urNx *~ -x *.orig ./Quickcheck_Narrowing.thy ../../src/HOL/Quickcheck_Narr
  subsection \<open>Narrowing for integers\<close>
  
  
-@@ -264,6 +270,7 @@
+@@ -265,6 +271,7 @@
  
  end
  
@@ -349,7 +363,7 @@ diff -urNx *~ -x *.orig ./Quickcheck_Narrowing.thy ../../src/HOL/Quickcheck_Narr
  declare [[code drop: "partial_term_of :: int itself \<Rightarrow> _"]]
  
  lemma [code]:
-@@ -274,6 +281,7 @@
+@@ -275,6 +282,7 @@
       then Code_Evaluation.term_of (- (int_of_integer i) div 2)
       else Code_Evaluation.term_of ((int_of_integer i + 1) div 2))"
    by (rule partial_term_of_anything)+
@@ -357,7 +371,7 @@ diff -urNx *~ -x *.orig ./Quickcheck_Narrowing.thy ../../src/HOL/Quickcheck_Narr
  
  instantiation integer :: narrowing
  begin
-@@ -286,6 +294,7 @@
+@@ -287,6 +295,7 @@
  
  end
  
@@ -365,7 +379,7 @@ diff -urNx *~ -x *.orig ./Quickcheck_Narrowing.thy ../../src/HOL/Quickcheck_Narr
  declare [[code drop: "partial_term_of :: integer itself \<Rightarrow> _"]]  
  
  lemma [code]:
-@@ -296,6 +305,7 @@
+@@ -297,6 +306,7 @@
       then Code_Evaluation.term_of (- i div 2)
       else Code_Evaluation.term_of ((i + 1) div 2))"
    by (rule partial_term_of_anything)+
@@ -373,10 +387,10 @@ diff -urNx *~ -x *.orig ./Quickcheck_Narrowing.thy ../../src/HOL/Quickcheck_Narr
  
  code_printing constant "Code_Evaluation.term_of :: integer \<Rightarrow> term" \<rightharpoonup> (Haskell_Quickcheck) 
    "(let { t = Typerep.Typerep \"Code'_Numeral.integer\" [];
-diff -urNx *~ -x *.orig ./Quickcheck_Random.thy ../../src/HOL/Quickcheck_Random.thy
---- ./Quickcheck_Random.thy	2024-12-18 15:58:48
-+++ ../../src/HOL/Quickcheck_Random.thy	2024-12-18 15:55:54
-@@ -229,7 +229,7 @@
+diff -urNx '*~' -x '*.orig' Quickcheck_Random.thy Quickcheck_Random.thy
+--- Quickcheck_Random.thy	2025-03-12 19:39:00.000000000 +0900
++++ Quickcheck_Random.thy	2025-12-11 13:22:51.038338543 +0900
+@@ -230,7 +230,7 @@
         (Code_Numeral.Suc i,
          random j \<circ>\<rightarrow> (%x. random_aux_set i j \<circ>\<rightarrow> (%s. Pair (valtermify_insert x s))))])"
  
@@ -385,9 +399,9 @@ diff -urNx *~ -x *.orig ./Quickcheck_Random.thy ../../src/HOL/Quickcheck_Random.
    "random_aux_set i j =
      collapse (Random.select_weight [(1, Pair valterm_emptyset),
        (i, random j \<circ>\<rightarrow> (%x. random_aux_set (i - 1) j \<circ>\<rightarrow> (%s. Pair (valtermify_insert x s))))])"
-diff -urNx *~ -x *.orig ./String.thy ../../src/HOL/String.thy
---- ./String.thy	2024-12-18 15:58:48
-+++ ../../src/HOL/String.thy	2024-12-18 15:55:55
+diff -urNx '*~' -x '*.orig' String.thy String.thy
+--- String.thy	2025-03-12 19:39:00.000000000 +0900
++++ String.thy	2025-12-11 13:22:51.038338543 +0900
 @@ -40,11 +40,21 @@
  
  lemma (in comm_semiring_1) of_nat_of_char:
@@ -412,7 +426,7 @@ diff -urNx *~ -x *.orig ./String.thy ../../src/HOL/String.thy
  
  lemma nat_of_char [simp]:
    \<open>nat (of_char c) = of_char c\<close>
-@@ -698,9 +708,9 @@
+@@ -714,9 +724,9 @@
  
  lemma [code]:
    \<open>Literal' b0 b1 b2 b3 b4 b5 b6 s = String.literal_of_asciis
@@ -424,10 +438,10 @@ diff -urNx *~ -x *.orig ./String.thy ../../src/HOL/String.thy
      by simp
    moreover have \<open>Literal' b0 b1 b2 b3 b4 b5 b6 s = String.literal_of_asciis
      [of_char (Char b0 b1 b2 b3 b4 b5 b6 False)] + s\<close>
-diff -urNx *~ -x *.orig ./Tools/Quickcheck/exhaustive_generators.ML ../../src/HOL/Tools/Quickcheck/exhaustive_generators.ML
---- ./Tools/Quickcheck/exhaustive_generators.ML	2024-12-18 15:58:48
-+++ ../../src/HOL/Tools/Quickcheck/exhaustive_generators.ML	2024-12-18 15:55:54
-@@ -546,7 +546,7 @@
+diff -urNx '*~' -x '*.orig' Tools/Quickcheck/exhaustive_generators.ML Tools/Quickcheck/exhaustive_generators.ML
+--- Tools/Quickcheck/exhaustive_generators.ML	2025-03-12 19:39:00.000000000 +0900
++++ Tools/Quickcheck/exhaustive_generators.ML	2025-12-11 13:22:51.039338527 +0900
+@@ -544,7 +544,7 @@
          instantiate_bounded_forall_datatype)))
  
  val active = Attrib.setup_config_bool \<^binding>\<open>quickcheck_exhaustive_active\<close> (K true)
@@ -436,16 +450,16 @@ diff -urNx *~ -x *.orig ./Tools/Quickcheck/exhaustive_generators.ML ../../src/HO
  val _ =
    Theory.setup
     (Quickcheck_Common.datatype_interpretation \<^plugin>\<open>quickcheck_full_exhaustive\<close>
-@@ -554,5 +554,5 @@
+@@ -552,5 +552,5 @@
      #> Context.theory_map (Quickcheck.add_tester ("exhaustive", (active, test_goals)))
      #> Context.theory_map (Quickcheck.add_batch_generator ("exhaustive", compile_generator_exprs))
      #> Context.theory_map (Quickcheck.add_batch_validator ("exhaustive", compile_validator_exprs)))
 -
 +*)
  end
-diff -urNx *~ -x *.orig ./Tools/Quickcheck/narrowing_generators.ML ../../src/HOL/Tools/Quickcheck/narrowing_generators.ML
---- ./Tools/Quickcheck/narrowing_generators.ML	2024-12-18 15:58:48
-+++ ../../src/HOL/Tools/Quickcheck/narrowing_generators.ML	2024-12-18 15:55:54
+diff -urNx '*~' -x '*.orig' Tools/Quickcheck/narrowing_generators.ML Tools/Quickcheck/narrowing_generators.ML
+--- Tools/Quickcheck/narrowing_generators.ML	2025-03-12 19:39:00.000000000 +0900
++++ Tools/Quickcheck/narrowing_generators.ML	2025-12-11 13:22:51.039338527 +0900
 @@ -542,8 +542,10 @@
    Theory.setup
     (Code.datatype_interpretation ensure_partial_term_of
@@ -457,9 +471,9 @@ diff -urNx *~ -x *.orig ./Tools/Quickcheck/narrowing_generators.ML ../../src/HOL
      #> Context.theory_map (Quickcheck.add_tester ("narrowing", (active, test_goals))))
  
  end
-diff -urNx *~ -x *.orig ./Tools/Quickcheck/random_generators.ML ../../src/HOL/Tools/Quickcheck/random_generators.ML
---- ./Tools/Quickcheck/random_generators.ML	2024-12-18 15:58:48
-+++ ../../src/HOL/Tools/Quickcheck/random_generators.ML	2024-12-18 15:55:54
+diff -urNx '*~' -x '*.orig' Tools/Quickcheck/random_generators.ML Tools/Quickcheck/random_generators.ML
+--- Tools/Quickcheck/random_generators.ML	2025-03-12 19:39:00.000000000 +0900
++++ Tools/Quickcheck/random_generators.ML	2025-12-11 13:22:51.039338527 +0900
 @@ -481,10 +481,12 @@
  
  val active = Attrib.setup_config_bool \<^binding>\<open>quickcheck_random_active\<close> (K false);
@@ -473,10 +487,10 @@ diff -urNx *~ -x *.orig ./Tools/Quickcheck/random_generators.ML ../../src/HOL/To
 +*)
  
  end;
-diff -urNx *~ -x *.orig ./Transcendental.thy ../../src/HOL/Transcendental.thy
---- ./Transcendental.thy	2024-12-18 15:58:48
-+++ ../../src/HOL/Transcendental.thy	2024-12-18 15:55:54
-@@ -3572,8 +3572,9 @@
+diff -urNx '*~' -x '*.orig' Transcendental.thy Transcendental.thy
+--- Transcendental.thy	2025-03-12 19:39:00.000000000 +0900
++++ Transcendental.thy	2025-12-11 13:22:51.041338495 +0900
+@@ -3526,8 +3526,9 @@
          using \<open>n \<le> p\<close> neq0_conv that(1) by blast
        then have \<section>: "(- 1::real) ^ (p div 2 - Suc 0) = - ((- 1) ^ (p div 2))"
          using \<open>even p\<close> by (auto simp add: dvd_def power_eq_if)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@
     - To update the patch:
     
     ```bash
-    diff -urNx '*~' -x '*.orig' $path_to_unpatched_Isabelle_dir/src/HOL $path_to_patched_Isabelle_dir/src/HOL | sed -e "s|$path_to_unpatched_Isabelle_dir/src/HOL||" -e "s|$path_to_patched_Isabelle_dir/src/HOL||" > HOL.patch
+    diff -urNx '*~' -x '*.orig' $path_to_unpatched_Isabelle_dir/src/HOL $path_to_patched_Isabelle_dir/src/HOL > HOL.patch
     ```
 
 ## How to make Isabelle record proofs?

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Performance on a machine with 32 processors i9-13950HX and 64 Go RAM
 | HOL\_Int\_wp                   | 1m53s |     33M | 2m15s |    239M |     |    |       |       |
 | HOL\_Set\_Interval\_wp         | 2m40s |     45M | 8m35s |      1G |     |    |       |       |
 | HOL\_Presburger\_wp            | 2m25s |     42M | 7m26s |      1G |     |    |       |       |
-| HOL\_List\_wp                  | 6m53s |     46M |       |         |     |    |       |       |
+| HOL\_List\_wp                  |       |         |       |         |     |    |       |       |
 | HOL\_Enum\_wp                  |       |         |       |         |     |    |       |       |
 | HOL\_Quickcheck\_Random\_wp    |       |         |       |         |     |    |       |       |
 | HOL\_Quickcheck\_Narrowing\_wp |       |         |       |         |     |    |       |       |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@
     - To update the patch:
     
     ```bash
-    diff -urNx '*~' -x '*.orig' $path_to_unpatched_Isabelle_dir/src/HOL $path_to_patched_Isabelle_dir/src/HOL > HOL.patch
+    diff -urNx '*~' -x '*.orig' $path_to_unpatched_Isabelle_dir/src/HOL $path_to_patched_Isabelle_dir/src/HOL | sed -e "s|$path_to_unpatched_Isabelle_dir/src/HOL||" -e "s|$path_to_patched_Isabelle_dir/src/HOL||" > HOL.patch
     ```
 
 ## How to make Isabelle record proofs?
@@ -155,23 +155,23 @@ Remark: the translation to Lambdapi and Rocq is still work in progress.
 Performance on a machine with 32 processors i9-13950HX and 64 Go RAM
 (but multiprocessing is used in v and vo only for the moment):
 
-| SESSION               | build | db size |    dk | dk size | dko |  v |    vo |   lpo |
-|:----------------------|------:|--------:|------:|--------:|----:|---:|------:|------:|
-| Pure                  |    2s |       0 |    2s |     60K |  0s | 0s |    1s |    3s |
-| Groups                |   15s |      7M |   12s |     11M |  1s | 0s |   15s |    3s |
-| Nat                   |   53s |     19M |  1m4s |    107M | 12s | 2s | 3m26s |   28s |
-| BNF\_Def              | 1m41s |     29M | 2m36s |    328M | 40s | 7s | 13m4s | 1m37s |
-| Int                   | 1m53s |     33M | 2m15s |    239M |     |    |       |       |
-| Set\_Interval         |       |         |       |         |     |    |       |       |
-| Presburger            |       |         |       |         |     |    |       |       |
-| List                  |       |         |       |         |     |    |       |       |
-| Enum                  |       |         |       |         |     |    |       |       |
-| Quickcheck\_Random    |       |         |       |         |     |    |       |       |
-| Quickcheck\_Narrowing |       |         |       |         |     |    |       |       |
-| Main                  |       |         |       |         |     |    |       |       |
-| Pre\_Transcendental   |       |         |       |         |     |    |       |       |
-| Transcendental        |       |         |       |         |     |    |       |       |
-| Complex\_Main         |       |         |       |         |     |    |       |       |
+| SESSION                        | build | db size |    dk | dk size | dko |  v |    vo |   lpo |
+|:-------------------------------|------:|--------:|------:|--------:|----:|---:|------:|------:|
+| Pure                           |    2s |       0 |    2s |     60K |  0s | 0s |    1s |    3s |
+| HOL\_Groups\_wp                |   15s |      7M |   12s |     11M |  1s | 0s |   15s |    3s |
+| HOL\_Nat\_wp                   |   53s |     19M |  1m4s |    107M | 12s | 2s | 3m26s |   28s |
+| HOL\_BNF\_Def\_wp              | 1m41s |     29M | 2m36s |    328M | 40s | 7s | 13m4s | 1m37s |
+| HOL\_Int\_wp                   | 1m53s |     33M | 2m15s |    239M |     |    |       |       |
+| HOL\_Set\_Interval\_wp         | 2m40s |     45M | 8m35s |      1G |     |    |       |       |
+| HOL\_Presburger\_wp            | 2m25s |     42M | 7m26s |      1G |     |    |       |       |
+| HOL\_List\_wp                  | 6m53s |     46M |       |         |     |    |       |       |
+| HOL\_Enum\_wp                  |       |         |       |         |     |    |       |       |
+| HOL\_Quickcheck\_Random\_wp    |       |         |       |         |     |    |       |       |
+| HOL\_Quickcheck\_Narrowing\_wp |       |         |       |         |     |    |       |       |
+| HOL\_Main\_wp                  |       |         |       |         |     |    |       |       |
+| HOL\_Pre\_Transcendental\_wp   |       |         |       |         |     |    |       |       |
+| HOL\_Transcendental\_wp        |       |         |       |         |     |    |       |       |
+| HOL\_Complex\_Main\_wp         |       |         |       |         |     |    |       |       |
 
 There is room for many important improvements. Makarius Wenzel is working on improving the export of proof terms in Isabelle. The generation of dk files is not modular. No term sharing is currently used in dk and v files.
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -24,8 +24,10 @@ ROCQ_OPTIONS = -q -no-glob
 ROOT_DIR = .
 OUT_DIR = .
 
-SESSION_DIR := $(ROOT_DIR)/$(SESSION)
 TIME := /usr/bin/time -f %e
+SESSION_DIR := $(ROOT_DIR)/$(SESSION)
+# dk does not allow . and - in module names, they are replaced by _
+SESSION_MODNAME := session_$(subst .,_,$(subst -,_,$(SESSION)))
 
 ############# generation of Isabelle proofs ##############
 
@@ -37,9 +39,6 @@ isadb_dir.mk:
 .PHONY: clean-isadb-dir.mk
 clean-isadb_dir.mk:
 	rm -f isadb_dir.mk
-
-# dk does not allow . and - in module names, they are replaced by _
-SESSION_MODNAME := session_$(subst .,_,$(subst -,_,$(SESSION)))
 
 ifneq ($(SESSION),"Pure")
 .PHONY: build
@@ -65,9 +64,11 @@ dk: $(OUT_DIR)/$(SESSION_MODNAME).dk
 ifeq ($(SESSION),Pure)
 $(OUT_DIR)/$(SESSION_MODNAME).dk: $(OUT_DIR)/STTfa.dk
 	isabelle dedukti_generate -k -d$(ROOT_DIR) -D$(OUT_DIR) $(ISADK_OPT) $(SESSION)
+	@touch $@
 else
 $(OUT_DIR)/$(SESSION_MODNAME).dk: $(ISADB_DIR)/$(SESSION).db $(OUT_DIR)/STTfa.dk
 	isabelle dedukti_generate -k -d$(ROOT_DIR) -D$(OUT_DIR) $(ISADK_OPT) $(SESSION)
+	@touch $@
 endif
 
 $(OUT_DIR)/STTfa.dk: $(ISADK_DIR)/STTfa.dk

--- a/examples/ROOT
+++ b/examples/ROOT
@@ -1,80 +1,80 @@
-session HOL_Groups in HOL_Groups = Pure +
+session HOL_Groups_wp in HOL_Groups_wp = Pure +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.Groups
 
-session HOL_Nat in HOL_Nat = HOL_Groups +
+session HOL_Nat_wp in HOL_Nat_wp = HOL_Groups +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.Nat
 
-session HOL_BNF_Def in HOL_BNF_Def = HOL_Nat +
+session HOL_BNF_Def_wp in HOL_BNF_Def_wp = HOL_Nat +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.BNF_Def
 
-session HOL_Int in HOL_Int = HOL_BNF_Def +
+session HOL_Int_wp in HOL_Int_wp = HOL_BNF_Def +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.Int
 
-session HOL_Set_Interval in HOL_Set_Interval = HOL_Int +
+session HOL_Set_Interval_wp in HOL_Set_Interval_wp = HOL_Int +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.Set_Interval
 
-session HOL_Presburger in HOL_Presburger = HOL_Set_Interval +
+session HOL_Presburger_wp in HOL_Presburger_wp = HOL_Set_Interval +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.Presburger
 
-session HOL_List in HOL_List = HOL_Presburger +
+session HOL_List_wp in HOL_List_wp = HOL_Presburger +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.List
 
-session HOL_Enum in HOL_Enum = HOL_List +
+session HOL_Enum_wp in HOL_Enum_wp = HOL_List +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.Enum
 
-session HOL_Quickcheck_Random in HOL_Quickcheck_Random = HOL_Enum +
+session HOL_Quickcheck_Random_wp in HOL_Quickcheck_Random_wp = HOL_Enum +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
 	HOL.Quickcheck_Random
 
-session HOL_Quickcheck_Narrowing in HOL_Quickcheck_Narrowing = HOL_Quickcheck_Random +
+session HOL_Quickcheck_Narrowing_wp in HOL_Quickcheck_Narrowing_wp = HOL_Quickcheck_Random +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
 	HOL.Quickcheck_Narrowing
 
-session HOL_Main in HOL_Main = HOL_Quickcheck_Narrowing +
+session HOL_Main_wp in HOL_Main_wp = HOL_Quickcheck_Narrowing +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     Main
 
-session HOL_Pre_Transcendental in HOL_Pre_Transcendental = HOL_Main +
+session HOL_Pre_Transcendental_wp in HOL_Pre_Transcendental_wp = HOL_Main +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories HOL.Series HOL.Deriv HOL.NthRoot
 
-session HOL_Transcendental in HOL_Transcendental = HOL_Pre_Transcendental +
+session HOL_Transcendental_wp in HOL_Transcendental_wp = HOL_Pre_Transcendental +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories HOL.Transcendental
 
-session HOL_Complex_Main in HOL = HOL_Main +
+session HOL_Complex_Main_wp in HOL_wp = HOL_Main +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories

--- a/examples/ROOT
+++ b/examples/ROOT
@@ -4,77 +4,77 @@ session HOL_Groups_wp in HOL_Groups_wp = Pure +
   theories
     HOL.Groups
 
-session HOL_Nat_wp in HOL_Nat_wp = HOL_Groups +
+session HOL_Nat_wp in HOL_Nat_wp = HOL_Groups_wp +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.Nat
 
-session HOL_BNF_Def_wp in HOL_BNF_Def_wp = HOL_Nat +
+session HOL_BNF_Def_wp in HOL_BNF_Def_wp = HOL_Nat_wp +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.BNF_Def
 
-session HOL_Int_wp in HOL_Int_wp = HOL_BNF_Def +
+session HOL_Int_wp in HOL_Int_wp = HOL_BNF_Def_wp +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.Int
 
-session HOL_Set_Interval_wp in HOL_Set_Interval_wp = HOL_Int +
+session HOL_Set_Interval_wp in HOL_Set_Interval_wp = HOL_Int_wp +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.Set_Interval
 
-session HOL_Presburger_wp in HOL_Presburger_wp = HOL_Set_Interval +
+session HOL_Presburger_wp in HOL_Presburger_wp = HOL_Set_Interval_wp +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.Presburger
 
-session HOL_List_wp in HOL_List_wp = HOL_Presburger +
+session HOL_List_wp in HOL_List_wp = HOL_Presburger_wp +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.List
 
-session HOL_Enum_wp in HOL_Enum_wp = HOL_List +
+session HOL_Enum_wp in HOL_Enum_wp = HOL_List_wp +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     HOL.Enum
 
-session HOL_Quickcheck_Random_wp in HOL_Quickcheck_Random_wp = HOL_Enum +
+session HOL_Quickcheck_Random_wp in HOL_Quickcheck_Random_wp = HOL_Enum_wp +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
 	HOL.Quickcheck_Random
 
-session HOL_Quickcheck_Narrowing_wp in HOL_Quickcheck_Narrowing_wp = HOL_Quickcheck_Random +
+session HOL_Quickcheck_Narrowing_wp in HOL_Quickcheck_Narrowing_wp = HOL_Quickcheck_Random_wp +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
 	HOL.Quickcheck_Narrowing
 
-session HOL_Main_wp in HOL_Main_wp = HOL_Quickcheck_Narrowing +
+session HOL_Main_wp in HOL_Main_wp = HOL_Quickcheck_Narrowing_wp +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories
     Main
 
-session HOL_Pre_Transcendental_wp in HOL_Pre_Transcendental_wp = HOL_Main +
+session HOL_Pre_Transcendental_wp in HOL_Pre_Transcendental_wp = HOL_Main_wp +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories HOL.Series HOL.Deriv HOL.NthRoot
 
-session HOL_Transcendental_wp in HOL_Transcendental_wp = HOL_Pre_Transcendental +
+session HOL_Transcendental_wp in HOL_Transcendental_wp = HOL_Pre_Transcendental_wp +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories HOL.Transcendental
 
-session HOL_Complex_Main_wp in HOL_wp = HOL_Main +
+session HOL_Complex_Main_wp in HOL_wp = HOL_Main_wp +
   options [strict_facts,export_theory,export_proofs,record_proofs=2]
   sessions HOL
   theories


### PR DESCRIPTION
revert 3e4c77c92b9bc88bb2d6d5f645c05e973ce13455: put back the _wp suffix for session names because db session names are shared between the various isabelle version a user can have
