### PR TITLE
revert suffixing types with _type

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,23 +155,23 @@ Remark: the translation to Lambdapi and Rocq is still work in progress.
 Performance on a machine with 32 processors i9-13950HX and 64 Go RAM
 (but multiprocessing is used in v and vo only for the moment):
 
-| SESSION                        | build | db size |    dk | dk size | dko |  v |    vo |   lpo |
-|:-------------------------------|------:|--------:|------:|--------:|----:|---:|------:|------:|
-| Pure                           |    2s |       0 |    2s |     60K |  0s | 0s |    1s |    3s |
-| HOL\_Groups\_wp                |   15s |      7M |   12s |     11M |  1s | 0s |   15s |    3s |
-| HOL\_Nat\_wp                   |   53s |     19M |  1m4s |    107M | 12s | 2s | 3m26s |   28s |
-| HOL\_BNF\_Def\_wp              | 1m41s |     29M | 2m36s |    328M | 40s | 7s | 13m4s | 1m37s |
-| HOL\_Int\_wp                   | 1m53s |     33M | 2m15s |    239M |     |    |       |       |
-| HOL\_Set\_Interval\_wp         | 2m40s |     45M | 8m35s |      1G |     |    |       |       |
-| HOL\_Presburger\_wp            | 2m25s |     42M | 7m26s |      1G |     |    |       |       |
-| HOL\_List\_wp                  | 6m53s |     46M |       |         |     |    |       |       |
-| HOL\_Enum\_wp                  |       |         |       |         |     |    |       |       |
-| HOL\_Quickcheck\_Random\_wp    |       |         |       |         |     |    |       |       |
-| HOL\_Quickcheck\_Narrowing\_wp |       |         |       |         |     |    |       |       |
-| HOL\_Main\_wp                  |       |         |       |         |     |    |       |       |
-| HOL\_Pre\_Transcendental\_wp   |       |         |       |         |     |    |       |       |
-| HOL\_Transcendental\_wp        |       |         |       |         |     |    |       |       |
-| HOL\_Complex\_Main\_wp         |       |         |       |         |     |    |       |       |
+| SESSION                        | build | db size |    dk | dk size | dko |  v |     vo |   lpo |
+|:-------------------------------|------:|--------:|------:|--------:|----:|---:|-------:|------:|
+| Pure                           |    2s |       0 |    2s |     60K |  0s | 0s |     1s |    0s |
+| HOL\_Groups\_wp                |   15s |      7M |   12s |     12M |  1s | 0s |    13s |    3s |
+| HOL\_Nat\_wp                   |   53s |     19M |  1m3s |    106M | 10s | 2s |  3m13s |  1m3s |
+| HOL\_BNF\_Def\_wp              | 1m41s |     29M | 2m32s |    328M | 29s | 7s | 12m45s | 1m57s |
+| HOL\_Int\_wp                   | 1m53s |     33M |       |         |     |    |        |       |
+| HOL\_Set\_Interval\_wp         | 2m40s |     45M |       |         |     |    |        |       |
+| HOL\_Presburger\_wp            | 2m25s |     42M |       |         |     |    |        |       |
+| HOL\_List\_wp                  | 6m53s |     46M |       |         |     |    |        |       |
+| HOL\_Enum\_wp                  |       |         |       |         |     |    |        |       |
+| HOL\_Quickcheck\_Random\_wp    |       |         |       |         |     |    |        |       |
+| HOL\_Quickcheck\_Narrowing\_wp |       |         |       |         |     |    |        |       |
+| HOL\_Main\_wp                  |       |         |       |         |     |    |        |       |
+| HOL\_Pre\_Transcendental\_wp   |       |         |       |         |     |    |        |       |
+| HOL\_Transcendental\_wp        |       |         |       |         |     |    |        |       |
+| HOL\_Complex\_Main\_wp         |       |         |       |         |     |    |        |       |
 
 There is room for many important improvements. Makarius Wenzel is working on improving the export of proof terms in Isabelle. The generation of dk files is not modular. No term sharing is currently used in dk and v files.
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -45,8 +45,7 @@ ifneq ($(SESSION),"Pure")
 build: $(ISADB_DIR)/$(SESSION).db
 
 $(ISADB_DIR)/%.db: $(ROOT_DIR)/ROOT $(SESSION_DIR)
-	isabelle build -b -d$(ROOT_DIR) $*
-	@touch $@
+	@if test -f $@; then touch $@; else isabelle build -b -d$(ROOT_DIR) $*; fi
 
 $(SESSION_DIR):
 	mkdir -p $@
@@ -172,9 +171,9 @@ $(OUT_DIR)/mappings.v: $(ISADK_DIR)/mappings.v
 	@echo lambdapi export -o stt_coq $<
 	@$(LAMBDAPI) export -o stt_coq --encoding $(ISADK_DIR)/encoding.lp --mapping $(ISADK_DIR)/mappings.lp --renaming $(ISADK_DIR)/renaming.lp --requiring mappings $< | sed -e '/^Require STTfa\./d' > $@
 
-%.v: %.lp
-	@echo lambdapi export -o stt_coq $<
-	@$(LAMBDAPI) export -o stt_coq --encoding $(ISADK_DIR)/encoding.lp --mapping $(ISADK_DIR)/mappings.lp --renaming $(ISADK_DIR)/renaming.lp --requiring mappings $< | sed -e '/^Require Isabelle\.STTfa\./d' > $@
+#%.v: %.lp
+#	@echo lambdapi export -o stt_coq $<
+#	@$(LAMBDAPI) export -o stt_coq --encoding $(ISADK_DIR)/encoding.lp --mapping $(ISADK_DIR)/mappings.lp --renaming $(ISADK_DIR)/renaming.lp --requiring mappings $< | sed -e '/^Require Isabelle\.STTfa\./d' > $@
 
 .PHONY: clean-v
 clean-v: rm-v rm-vo-mk clean-vo

--- a/src/translate.scala
+++ b/src/translate.scala
@@ -101,29 +101,26 @@ object Prelude {
    * @param kind the kind of the object (class, type, const, etc.)
    * @param module0 the current $dklp module
    * @return a unique translated id, after updating maps to account for it */
-  def add_name(id: String, kind: String, module: String) : String = {
-    val (translated_id,translated_module) = id match {
+  def add_name(id: String, kind: String, module0: String) : String = {
+    val (translated_id,module) = id match {
       case Pure_Thy.FUN => ("arr",STTfa)
       case Pure_Thy.PROP => ("prop",STTfa)
       case Pure_Thy.IMP => ("imp",STTfa)
       case Pure_Thy.ALL => ("all",STTfa)
       case id =>
         val cut = id.split("[.]", 2)
-        val (prefix,radical) = if (cut.length == 1) ("",cut(0)) else (cut(0),cut(1))
+        val (prefix, radical) = if (cut.length == 1) ("", cut(0)) else (cut(0), cut(1))
         // because Dedukti does not accept names with dots
         var translated_id = radical.replace(".","_")
         if (kind == "var") translated_id += "_"
-        if (kind == "type") translated_id += "_type"
-        if (namesSet(translated_id) && moduleOf(translated_id) != module) {
-          translated_id = prefix + "_" + translated_id
-        }
         if (namesSet(translated_id)) translated_id += "_" + kind
+        if (namesSet(translated_id)) translated_id = prefix + "_" + translated_id
         if (namesSet(translated_id)) error("duplicated name: " + translated_id)
-        (translated_id,module)
+        (translated_id,module0)
     }
     namesMap += full_name(id, kind) -> translated_id
     namesSet += translated_id
-    moduleOf += translated_id -> translated_module
+    moduleOf += translated_id -> module
     //println("add_name "+full_name(id,kind)+" -> "+translated_id)
     translated_id
   }


### PR DESCRIPTION
Revert the changes of #42 in translate.scala (using _type as suffix for types) as it breaks the translation to rocq. Changing the naming of types requires to update mapping.lp and mapping.v at the same time.
