### PR TITLE
use of eta-contraction/expansion

### DIFF
--- a/src/exporter.scala
+++ b/src/exporter.scala
@@ -115,7 +115,7 @@ object Exporter {
       case _ => error("exporter.abs: not a free variable "+arg.toString)
     }
   }
-
+  
   /** whether an $isa term is a specific (possibly eta_expanded) free variable
    * 
    * @param term the $isa term to test

--- a/src/exporter.scala
+++ b/src/exporter.scala
@@ -163,7 +163,7 @@ object Exporter {
     /** depending on variable <code>to_lp</code>, opens an [[LP_Writer]] or a [[DK_Writer]] */
     def new_Writer(writer: Writer): Abstract_Writer =
       if (to_lp) {
-        writer.write("""flag "eta_equality" on;""")
+        if(!eta_expand) writer.write("""flag "eta_equality" on;""")
         writer.write('\n')
         new LP_Writer(use_notations,writer)
       }

--- a/src/exporter.scala
+++ b/src/exporter.scala
@@ -163,8 +163,10 @@ object Exporter {
     /** depending on variable <code>to_lp</code>, opens an [[LP_Writer]] or a [[DK_Writer]] */
     def new_Writer(writer: Writer): Abstract_Writer =
       if (to_lp) {
-        if(!eta_expand) writer.write("""flag "eta_equality" on;""")
-        writer.write('\n')
+        if(!eta_expand) {
+          writer.write("""flag "eta_equality" on;""")
+          writer.write('\n')
+        }
         new LP_Writer(use_notations,writer)
       }
       else new DK_Writer(writer)
@@ -329,6 +331,12 @@ object Exporter {
           val thm = a.the_content
           Translate.stmt_decl(Prelude.add_thm_ident(a.name, theory_name), thm.prop, None)
           update_useless_proofs(a.name, thm.proof, thm.prop.args.map(_._1).reverse)
+        }
+        /* eta_expansion reads the type of terms from the Translate.global_types map,
+        *  which means that we must also read (useful) proofs to update this map */
+        if (eta_expand) for (a <- map_theory_proofs(theory_name) if !Translate.replace_serial.contains(a)) {
+          if (verbose) progress.echo("  proof " + a.toString)
+          decl_proof(a, theory_name)
         }
         progress.echo("End reading theory "+theory_name)
       }

--- a/src/exporter.scala
+++ b/src/exporter.scala
@@ -115,7 +115,7 @@ object Exporter {
       case _ => error("exporter.abs: not a free variable "+arg.toString)
     }
   }
-  
+
   /** whether an $isa term is a specific (possibly eta_expanded) free variable
    * 
    * @param term the $isa term to test

--- a/src/translate.scala
+++ b/src/translate.scala
@@ -101,29 +101,26 @@ object Prelude {
    * @param kind the kind of the object (class, type, const, etc.)
    * @param module0 the current $dklp module
    * @return a unique translated id, after updating maps to account for it */
-  def add_name(id: String, kind: String, module: String) : String = {
-    val (translated_id,translated_module) = id match {
+  def add_name(id: String, kind: String, module0: String) : String = {
+    val (translated_id,module) = id match {
       case Pure_Thy.FUN => ("arr",STTfa)
       case Pure_Thy.PROP => ("prop",STTfa)
       case Pure_Thy.IMP => ("imp",STTfa)
       case Pure_Thy.ALL => ("all",STTfa)
       case id =>
         val cut = id.split("[.]", 2)
-        val (prefix,radical) = if (cut.length == 1) ("",cut(0)) else (cut(0),cut(1))
+        val (prefix, radical) = if (cut.length == 1) ("", cut(0)) else (cut(0), cut(1))
         // because Dedukti does not accept names with dots
         var translated_id = radical.replace(".","_")
         if (kind == "var") translated_id += "_"
-        if (kind == "type") translated_id += "_type"
-        if (namesSet(translated_id) && moduleOf(translated_id) != module) {
-          translated_id = prefix + "_" + translated_id
-        }
         if (namesSet(translated_id)) translated_id += "_" + kind
+        if (namesSet(translated_id)) translated_id = prefix + "_" + translated_id
         if (namesSet(translated_id)) error("duplicated name: " + translated_id)
-        (translated_id,module)
+        (translated_id,module0)
     }
     namesMap += full_name(id, kind) -> translated_id
     namesSet += translated_id
-    moduleOf += translated_id -> translated_module
+    moduleOf += translated_id -> module
     //println("add_name "+full_name(id,kind)+" -> "+translated_id)
     translated_id
   }

--- a/src/translate.scala
+++ b/src/translate.scala
@@ -109,13 +109,13 @@ object Prelude {
       case Pure_Thy.ALL => ("all",STTfa)
       case id =>
         val cut = id.split("[.]", 2)
-        val radical = if (cut.length == 1) cut(0) else cut(1)
+        val (prefix,radical) = if (cut.length == 1) ("",cut(0)) else (cut(0),cut(1))
         // because Dedukti does not accept names with dots
         var translated_id = radical.replace(".","_")
         if (kind == "var") translated_id += "_"
         if (kind == "type") translated_id += "_type"
         if (namesSet(translated_id) && moduleOf(translated_id) != module) {
-          translated_id = module + "_" + translated_id
+          translated_id = prefix + "_" + translated_id
         }
         if (namesSet(translated_id)) translated_id += "_" + kind
         if (namesSet(translated_id)) error("duplicated name: " + translated_id)

--- a/src/translate.scala
+++ b/src/translate.scala
@@ -101,26 +101,29 @@ object Prelude {
    * @param kind the kind of the object (class, type, const, etc.)
    * @param module0 the current $dklp module
    * @return a unique translated id, after updating maps to account for it */
-  def add_name(id: String, kind: String, module0: String) : String = {
-    val (translated_id,module) = id match {
+  def add_name(id: String, kind: String, module: String) : String = {
+    val (translated_id,translated_module) = id match {
       case Pure_Thy.FUN => ("arr",STTfa)
       case Pure_Thy.PROP => ("prop",STTfa)
       case Pure_Thy.IMP => ("imp",STTfa)
       case Pure_Thy.ALL => ("all",STTfa)
       case id =>
         val cut = id.split("[.]", 2)
-        val (prefix, radical) = if (cut.length == 1) ("", cut(0)) else (cut(0), cut(1))
+        val radical = if (cut.length == 1) cut(0) else cut(1)
         // because Dedukti does not accept names with dots
         var translated_id = radical.replace(".","_")
         if (kind == "var") translated_id += "_"
-        if (kind == "type" || namesSet(translated_id)) translated_id += "_" + kind
-        if (namesSet(translated_id)) translated_id = prefix + "_" + translated_id
+        if (kind == "type") translated_id += "_type"
+        if (namesSet(translated_id) && moduleOf(translated_id) != module) {
+          translated_id = module + "_" + translated_id
+        }
+        if (namesSet(translated_id)) translated_id += "_" + kind
         if (namesSet(translated_id)) error("duplicated name: " + translated_id)
-        (translated_id,module0)
+        (translated_id,module)
     }
     namesMap += full_name(id, kind) -> translated_id
     namesSet += translated_id
-    moduleOf += translated_id -> module
+    moduleOf += translated_id -> translated_module
     //println("add_name "+full_name(id,kind)+" -> "+translated_id)
     translated_id
   }

--- a/src/translate.scala
+++ b/src/translate.scala
@@ -113,7 +113,7 @@ object Prelude {
         // because Dedukti does not accept names with dots
         var translated_id = radical.replace(".","_")
         if (kind == "var") translated_id += "_"
-        if (namesSet(translated_id)) translated_id += "_" + kind
+        if (kind == "type") translated_id += "_type"
         if (namesSet(translated_id)) translated_id = prefix + "_" + translated_id
         if (namesSet(translated_id)) error("duplicated name: " + translated_id)
         (translated_id,module0)

--- a/src/translate.scala
+++ b/src/translate.scala
@@ -739,7 +739,7 @@ object Translate {
    *  Where global_eta_expand is a variable
    */
   def eta_expand(tm: Syntax.Term) : Syntax.Term = {
-    if (global_eta_expand) eta_expand((eta_contract(tm), Map(), Mut("€a")) else tm
+    if (global_eta_expand) eta_expand(eta_contract(tm), Map(), Mut("€a")) else tm
   }
 
   /** Pop all compatible {abstraction, product} arguments and return their list and the remaining terms 
@@ -891,7 +891,7 @@ object Translate {
       case Some(rhs) => {
         val translated_rhs = typ(rhs)
         val full_tm : Syntax.Term = args.map(bound_type_argument(_)).foldRight(translated_rhs)(Syntax.Abst.apply)
-        val (new_args, contracted, ty) = fetch_head_args(eta_expand(full_tm)), full_ty)
+        val (new_args, contracted, ty) = fetch_head_args(eta_expand(full_tm), full_ty)
         Syntax.Definition(id_c, new_args, Some(ty), contracted, notation_decl(not))
       }
     }

--- a/src/translate.scala
+++ b/src/translate.scala
@@ -739,7 +739,7 @@ object Translate {
    *  Where global_eta_expand is a variable
    */
   def eta_expand(tm: Syntax.Term) : Syntax.Term = {
-    if (global_eta_expand) eta_expand(tm, Map(), Mut("€a")) else tm
+    if (global_eta_expand) eta_expand((eta_contract(tm), Map(), Mut("€a")) else tm
   }
 
   /** Pop all compatible {abstraction, product} arguments and return their list and the remaining terms 
@@ -891,7 +891,7 @@ object Translate {
       case Some(rhs) => {
         val translated_rhs = typ(rhs)
         val full_tm : Syntax.Term = args.map(bound_type_argument(_)).foldRight(translated_rhs)(Syntax.Abst.apply)
-        val (new_args, contracted, ty) = fetch_head_args(eta_expand(eta_contract(full_tm)), full_ty)
+        val (new_args, contracted, ty) = fetch_head_args(eta_expand(full_tm)), full_ty)
         Syntax.Definition(id_c, new_args, Some(ty), contracted, notation_decl(not))
       }
     }
@@ -961,7 +961,7 @@ object Translate {
     implArgsMap += id_c -> impl
     val bound_args = bound_type_arguments(typargs, impl)
     val full_ty = bound_args.foldRight(eta(typ(ty)))(Syntax.Prod.apply)
-    val contracted_ty = eta_expand(eta_contract(full_ty))
+    val contracted_ty = eta_expand(full_ty)
     global_types += id_c -> contracted_ty
     rhs match {
       case None =>
@@ -970,7 +970,7 @@ object Translate {
       case Some(rhs) => {
         val translated_rhs = term(rhs, Bounds())
         val full_tm = bound_args.foldRight(translated_rhs)(Syntax.Abst.apply)
-        val (new_args, contracted, final_ty) = fetch_head_args(eta_expand(eta_contract(full_tm)), contracted_ty)
+        val (new_args, contracted, final_ty) = fetch_head_args(eta_expand(full_tm), contracted_ty)
         Syntax.Definition(id_c, new_args, Some(final_ty), contracted, notation_decl(not))
       }
     }
@@ -992,7 +992,7 @@ object Translate {
       prop.args.map(arg => bound_term_argument(arg._1, arg._2))
 
     val full_ty = args.foldRight(eps(term(prop.term, Bounds())))(Syntax.Prod.apply)
-    val contracted_ty = eta_expand(eta_contract(full_ty))
+    val contracted_ty = eta_expand(full_ty)
 
     implArgsMap  += s -> List.fill(prop.typargs.length)(false) // Only those are applied immediately
     global_types += s -> contracted_ty
@@ -1006,7 +1006,7 @@ object Translate {
       case Some(prf) => {
         val translated_rhs = proof(prf, Bounds())
         val full_prf : Syntax.Term = args.foldRight(translated_rhs)(Syntax.Abst.apply)
-        val (new_args, contracted, final_ty) = fetch_head_args(eta_expand(eta_contract(full_prf)), contracted_ty)
+        val (new_args, contracted, final_ty) = fetch_head_args(eta_expand(full_prf), contracted_ty)
         Syntax.Theorem(s, new_args, final_ty, contracted)
       }
     }

--- a/src/translate.scala
+++ b/src/translate.scala
@@ -113,7 +113,7 @@ object Prelude {
         // because Dedukti does not accept names with dots
         var translated_id = radical.replace(".","_")
         if (kind == "var") translated_id += "_"
-        if (kind == "type") translated_id += "_type"
+        if (kind == "type" || namesSet(translated_id)) translated_id += "_" + kind
         if (namesSet(translated_id)) translated_id = prefix + "_" + translated_id
         if (namesSet(translated_id)) error("duplicated name: " + translated_id)
         (translated_id,module0)


### PR DESCRIPTION
- Do not use eta-contraction anymore outside of option -e
- Now also read unnamed proofs with option -e (still not needed otherwise)